### PR TITLE
switch br-text to `rewrite` workflow

### DIFF
--- a/br-text/backup.bash
+++ b/br-text/backup.bash
@@ -37,13 +37,16 @@ fi
 
 ## Handle existed data
 #
-if [ -f "${dir}/backup.lock" ]; then
-	if [ "${skip_exist}" == 'true' ]; then
+if [ -f "${dir}/backupmeta" ]; then
+	if [ "${exist_policy}" == 'skip' ]; then
 		echo "[:-] '${dir}' data exist, skipped"
 		exit 0
+	elif [ "${exist_policy}" == 'error' ]; then
+		echo "[:(] '${dir}' data exist, can't overwrite"
+		exit 1
 	else
 		if [ -z "${dir_root}" ]; then
-			echo "[:(] assert failed, '${dir}' not right"
+			echo "[:(] looks strange, can't remove '${dir}'"
 			exit 1
 		fi
 		echo "[:-] '${dir}' data exist, removing"

--- a/br-text/backup.bash.ticat
+++ b/br-text/backup.bash.ticat
@@ -1,11 +1,11 @@
-help = backup tidb cluster data
+help = backup tidb cluster data, exist-policy: skip|overwrite|error
 abbr = back|bk|b|B
 
 [arg]
 backup-dir|dir = ''
 cluster-name|cluster|name|n|N = ''
 tag|t|T = ''
-skip-exist|skip|s|S = true
+exist-policy|when-exist = overwrite
 threads|thread|thrd = 4
 check-checksum|checksum = true
 target-db|target|db = ''
@@ -17,7 +17,7 @@ br.checksum = check-checksum
 br.target = target-db
 tidb.cluster = cluster-name
 tidb.data.tag = tag
-tidb.backup.skip-exist = skip-exist
+tidb.backup.exist-policy = exist-policy
 
 [env]
 br.backup-dir = read
@@ -25,7 +25,7 @@ br.threads = read
 br.checksum = read
 tidb.cluster = read
 tidb.data.tag = read
-tidb.backup.skip-exist = read
+tidb.backup.exist-policy = read
 
 [dep]
 tiup = to display tidb cluster info and run br

--- a/br-text/br.rewrite.tiflow
+++ b/br-text/br.rewrite.tiflow
@@ -1,0 +1,1 @@
+help = a dummy command to make br and br-text has the same interface

--- a/br-text/rewrite.bash
+++ b/br-text/rewrite.bash
@@ -1,0 +1,27 @@
+set -euo pipefail
+
+here=`cd $(dirname ${BASH_SOURCE[0]}) && pwd`
+. "${here}/../helper/helper.bash"
+
+env=`cat "${1}/env"`
+shift
+
+tag=`must_env_val "${env}" 'tidb.data.tag'`
+dir_root=`must_env_val "${env}" 'br.backup-dir'`
+
+dir="${dir_root}/${tag}"
+dir_text="${dir_root}/rewrite-text${tag}"
+
+debug=`must_env_val "${env}" 'br-text.tikv.debug-build'`
+echo "[:-] use debug build = '${debug}'"
+rewrite_bin=`build_rewrite "${here}/../repos/tikv" "${debug}"`
+
+echo rm -rf "${dir_text}"
+rm -rf "${dir_text}"
+echo "${rewrite_bin}" "${dir}" "${dir_text}"
+"${rewrite_bin}" "${dir}" "${dir_text}"
+
+echo rm -rf "${dir}"
+rm -rf "${dir}"
+echo "${rewrite_bin}" "${dir_text}" "${dir}"
+"${rewrite_bin}" "${dir_text}" "${dir}"

--- a/br-text/rewrite.bash.ticat
+++ b/br-text/rewrite.bash.ticat
@@ -1,0 +1,19 @@
+help = rewrite tidb backup data
+
+[arg]
+backup-dir|dir = ''
+tag = ''
+debug-build|debug = false
+
+[arg2env]
+br.backup-dir = backup-dir
+br-text.tikv.debug-build = debug-build
+tidb.data.tag = tag
+
+[env]
+br.backup-dir = read
+br-text.tikv.debug-build = read
+tidb.data.tag = read
+
+[dep]
+cargo = to build rewrite

--- a/br-text/selftest.br-text.workload.tiflow
+++ b/br-text/selftest.br-text.workload.tiflow
@@ -7,14 +7,14 @@ checksum|cs = false
 threads|t|T = 1
 target-db|target|db = ''
 br = br-t
-skip-exist = false
+exist-policy = overwrite
 
 [arg2env]
 br.backup-dir = backup-dir
 br.checksum = checksum
 br.threads = threads
 br.target = target-db
-tidb.backup.skip-exist = skip-exist
+tidb.backup.exist-policy = exist-policy
 
 [env]
 bench.workload = read
@@ -22,16 +22,19 @@ bench.workload = read
 [flow/]
 bench.meta.100 :
 
-db.conf.test cluster=test-br-t : [[br]].patch-kv : db.rm : db.new :
+db.conf.test cluster=test-br-t : db.rm : db.new :
 
 [[bench.workload]].load : [[bench.workload]].run : bench.data.gen-tag :
 
-mark-time [[br]].backup.begin  : [[br]].backup  : mark-time [[br]].backup.end :
-bench.gen-tag add-key=br.threads : bench.dur.record [[br]].backup  :
+mark-time br.backup.begin : br.backup  : mark-time br.backup.end :
+bench.gen-tag add-key=br.threads : bench.dur.record br.backup :
 
-db.clean : db.up :
+db.clean : 
+mark-time [[br]].rewrite.begin : [[br]].rewrite : mark-time [[br]].rewrite.end :
+bench.gen-tag : bench.dur.record [[br]].rewrite :
+db.up :
 
-mark-time [[br]].restore.begin : [[br]].restore : mark-time [[br]].restore.end :
+mark-time [[br]].restore.begin : br.restore : mark-time [[br]].restore.end :
 bench.gen-tag add-key=br.threads : bench.dur.record [[br]].restore :
 
 [[bench.workload]].run : db.rm : bench.dur.show

--- a/helper/helper.bash
+++ b/helper/helper.bash
@@ -53,6 +53,17 @@ function build_br_t()
 	build_bin "${dir}" 'bin/br' 'make build_br'
 }
 
+function build_rewrite()
+{
+	local dir="${1}"
+	local debug=`to_true "${2}"`
+	if [ "${debug}" == 'true' ]; then
+		build_bin "${dir}" 'target/debug/rewrite' 'cargo build --package backup_text'
+	else
+		build_bin "${dir}" 'target/release/rewrite' 'cargo build --package backup_text --release'
+	fi
+}
+
 function build_tikv()
 {
 	local dir="${1}"


### PR DESCRIPTION
In this PR, we switch the workflow of backup-text to:
1. Backup the database by `tiup br backup` in SST format.
2. `Rewrite` backup files into text format, then `rewrite` it back to SST.
3. Restore the database by `tiup br restore`, using the SST files generated by step 2.